### PR TITLE
Adding qSync and qDrop.

### DIFF
--- a/lib/q-orm.js
+++ b/lib/q-orm.js
@@ -16,6 +16,8 @@ function setupConnectionMethods(connection) {
 
 	connection.qDefine = defineModel.bind(connection);
 	connection.qExecQuery = Q.nbind(connection.driver.execQuery, connection.driver);
+	connection.qSync = Q.nbind(connection.sync, connection);
+	connection.qDrop = Q.nbind(connection.drop, connection);
 
 	return connection;
 }
@@ -62,7 +64,7 @@ function defineModel(name, properties, opts) {
 
 	setupOneAssociations(Model, opts.hasOne);
 	setupManyAssociations(Model, opts.hasMany);
-	
+
 	return Model;
 
 }


### PR DESCRIPTION
Adding promised versions of sync and drop, making the following possible.

My model setup is something like this:

``` javascript
  var db

  return qOrm.qConnect(database)
    .then(function(dbIn) {
      db = dbIn

      // ... lots of qDefines from required files...

      if ('drop' in options) {return db.qDrop()}
    })
    .then(function() {return db.qSync()})
    .then(function() {return model})
```
